### PR TITLE
Add FastAPI backend with JWT auth and Next.js forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# Maximilian-Senfter
+# ShopOwner Demo
+
+This repository contains a basic FastAPI backend with PostgreSQL and JWT authentication, along with a minimal Next.js frontend for registration and login.
+
+## Backend
+
+Navigate to `backend` and install requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the API:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Environment variable `DATABASE_URL` should point to your PostgreSQL instance.
+
+## Frontend
+
+Navigate to `frontend` and install dependencies:
+
+```bash
+npm install
+```
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+The signup page is at `/signup` and login page at `/login`.

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+import os
+
+SECRET_KEY = os.getenv('SECRET_KEY', 'change-me')
+ALGORITHM = 'HS256'
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=['bcrypt'], deprecated='auto')
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({'exp': expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,10 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://user:password@localhost/shop')
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+from . import models, schemas, auth, database
+
+models.Base.metadata.create_all(bind=database.engine)
+
+app = FastAPI()
+
+# Dependency
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.post('/register')
+def register(shop_owner: schemas.ShopOwnerCreate, db: Session = Depends(get_db)):
+    existing = db.query(models.ShopOwner).filter_by(username=shop_owner.username).first()
+    if existing:
+        raise HTTPException(status_code=400, detail='Username already registered')
+    hashed = auth.get_password_hash(shop_owner.password)
+    db_shop_owner = models.ShopOwner(username=shop_owner.username, password_hash=hashed)
+    db.add(db_shop_owner)
+    db.commit()
+    db.refresh(db_shop_owner)
+    return {"id": db_shop_owner.id, "username": db_shop_owner.username}
+
+@app.post('/login')
+def login(shop_owner: schemas.ShopOwnerLogin, db: Session = Depends(get_db)):
+    db_owner = db.query(models.ShopOwner).filter_by(username=shop_owner.username).first()
+    if not db_owner or not auth.verify_password(shop_owner.password, db_owner.password_hash):
+        raise HTTPException(status_code=400, detail='Incorrect username or password')
+    token = auth.create_access_token({"sub": db_owner.username})
+    return {"access_token": token, "token_type": "bearer"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String
+from .database import Base
+
+class ShopOwner(Base):
+    __tablename__ = 'shop_owners'
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+class ShopOwnerCreate(BaseModel):
+    username: str
+    password: str
+
+class ShopOwnerLogin(BaseModel):
+    username: str
+    password: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+sqlalchemy
+psycopg2-binary
+passlib[bcrypt]
+python-jose
+pydantic

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "shop-owner-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+
+export default function Login() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const res = await fetch('http://localhost:8000/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    const data = await res.json()
+    console.log(data)
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+  )
+}

--- a/frontend/pages/signup.js
+++ b/frontend/pages/signup.js
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+
+export default function Signup() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    await fetch('http://localhost:8000/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Sign Up</button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- set up FastAPI backend using SQLAlchemy and JWT
- provide registration and login endpoints
- add basic Next.js pages for signup and login
- document running the services

## Testing
- `python -m py_compile backend/app/*.py`
- `node -v`
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6845dc9b33008330a6e59c4bfd78a645