### PR TITLE
Improve README setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,44 @@
 
 This repository contains a basic FastAPI backend with PostgreSQL and JWT authentication, along with a minimal Next.js frontend for registration and login.
 
+## Prerequisites
+
+- Python
+- Node.js and npm
+- PostgreSQL
+
+You can open the integrated terminal in VS Code via **View → Terminal** or with **Ctrl+`**.
+
 ## Backend
 
-Navigate to `backend` and install requirements:
+1. Open a terminal and navigate to the `backend` directory.
+2. Create and activate a Python virtual environment:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # Windows: venv\Scripts\activate
+   ```
+3. Install the backend requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Run the API with hot‑reload:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
 
-```bash
-pip install -r requirements.txt
-```
-
-Run the API:
-
-```bash
-uvicorn app.main:app --reload
-```
-
-Environment variable `DATABASE_URL` should point to your PostgreSQL instance.
+Ensure that the environment variable `DATABASE_URL` points to your PostgreSQL instance.
 
 ## Frontend
 
-Navigate to `frontend` and install dependencies:
+1. Open a **second terminal** (use the plus icon in the terminal panel).
+2. Navigate to the `frontend` directory.
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Start the development server:
+   ```bash
+   npm run dev
+   ```
 
-```bash
-npm install
-```
-
-Start the development server:
-
-```bash
-npm run dev
-```
-
-The signup page is at `/signup` and login page at `/login`.
+The signup page is available at `/signup` and the login page at `/login`.


### PR DESCRIPTION
## Summary
- add prerequisites section
- mention how to open the VS Code terminal
- expand backend instructions with a virtual environment and uvicorn
- show how to run the frontend in a second terminal

## Testing
- `pip install -r requirements.txt`
- `pytest` *(no tests found)*
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845f93d75548330bf86ced482de81b4