### PR TITLE
Add python-multipart to backend requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a basic FastAPI backend with PostgreSQL and JWT authent
 
 ## Backend
 
-Navigate to `backend` and install requirements:
+Navigate to `backend` and install requirements (these include `python-multipart` for handling `multipart/form-data`):
 
 ```bash
 pip install -r requirements.txt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary
 passlib[bcrypt]
 python-jose
 pydantic
+python-multipart


### PR DESCRIPTION
## Summary
- add `python-multipart` in `backend/requirements.txt`
- mention `python-multipart` in README quickstart

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_684ab482fd9483308acce01c0b08c394